### PR TITLE
Fix Artist not showing when using GPMDP

### DIFF
--- a/@Resources/include/MeasureMediaGPMDP.inc
+++ b/@Resources/include/MeasureMediaGPMDP.inc
@@ -18,7 +18,7 @@ PlayerInfo=Title
 Substitute="":"#NoTrackNameText#"
 UpdateDivider=100
 
-[MeasureTrack]
+[MeasureArtist]
 Measure=Plugin
 Plugin=GPMDPPlugin
 PlayerInfo=Artist


### PR DESCRIPTION
Probably a copy & paste error, was causing the artist field to not show when using Google Play Music Desktop Player due to misnamed Measure.